### PR TITLE
BI-2859: Update git url to use https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "bld/mongosql-auth-c"]
 	path = bld/mongosql-auth-c
-	url = git@github.com:mongodb/mongosql-auth-c
+	url = https://github.com/mongodb/mongosql-auth-c


### PR DESCRIPTION
Updating the url to use now that ssh keys are no longer present on Evergreen hosts.